### PR TITLE
Fix: domain change not working

### DIFF
--- a/src/URLFixer.php
+++ b/src/URLFixer.php
@@ -23,6 +23,7 @@ class URLFixer
 		add_filter('option_home', [$this, 'fixHomeURL']);
 		add_filter('option_siteurl', [$this, 'fixSiteURL']);
 		add_filter('network_site_url', [$this, 'fixNetworkSiteURL'], 10, 2);
+		add_action('wp_update_site', [$this, 'syncSiteurlOnDomainChange'], 10, 2);
 	}
 
 	/**
@@ -47,6 +48,19 @@ class URLFixer
 		}
 
 		return $url;
+	}
+
+	public function syncSiteurlOnDomainChange(\WP_Site $newSite, \WP_Site $oldSite): void
+	{
+		if ($newSite->domain === $oldSite->domain && $newSite->path === $oldSite->path) {
+			return;
+		}
+
+		$home = get_blog_option((int) $newSite->id, 'home');
+		$scheme = parse_url((string) $home, PHP_URL_SCHEME) ?: 'https';
+		$newSiteurl = rtrim($scheme . '://' . $newSite->domain . $newSite->path, '/') . '/wp';
+
+		update_blog_option((int) $newSite->id, 'siteurl', $newSiteurl);
 	}
 
 	/**


### PR DESCRIPTION
WordPress core (site-info.php) tries to update the siteurl option on domain change, but its path check fails because fixSiteURL appends /wp, making the stored path look like /wp/ while wp_blogs.path is /.